### PR TITLE
Elevators Dupe Fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 group = "com.lkeehl.elevators"
-version = "5.0.0-beta.6"
+version = "5.0.0-beta.7"
 description = "Fifth major semantic for the Elevators Spigot Plugin"
 java.sourceCompatibility = JavaVersion.VERSION_21
 

--- a/src/main/java/com/lkeehl/elevators/services/ListenerService.java
+++ b/src/main/java/com/lkeehl/elevators/services/ListenerService.java
@@ -41,7 +41,7 @@ public class ListenerService {
 
         registerEventExecutor(InventoryOpenEvent.class, EventPriority.LOWEST , InventoryEventExecutor::onInventoryOpen);
         registerEventExecutor(InventoryMoveItemEvent.class, EventPriority.LOWEST , InventoryEventExecutor::onHopperTake);
-        registerEventExecutor(InventoryClickEvent.class, EventPriority.LOWEST, InventoryEventExecutor::onClickStackHandler, true);
+        registerEventExecutor(InventoryClickEvent.class, EventPriority.HIGHEST, InventoryEventExecutor::onClickStackHandler, true);
         registerEventExecutor(PrepareAnvilEvent.class, EventPriority.LOWEST , InventoryEventExecutor::onAnvilPrepare);
         registerEventExecutor(CraftItemEvent.class, EventPriority.NORMAL , InventoryEventExecutor::onCraft);
 


### PR DESCRIPTION
Hi!
In the previous version (beta-6), there was a method to duplicate elevators using plugins that display inventories (like InteractiveChat) because the event was triggered before these plugins could handle it.
Here are the clips before and after the fix:

**Before fix:** https://imgur.com/a/4pO0iuG
**After fix:** https://imgur.com/a/dgcq4V5