### PR TITLE
Check on Floor Name Change and on Settings Change + SSB2 Hook

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 group = "com.lkeehl.elevators"
-version = "5.0.0-beta.8"
+version = "5.0.0-beta.9"
 description = "Fifth major semantic for the Elevators Spigot Plugin"
 java.sourceCompatibility = JavaVersion.VERSION_21
 
@@ -25,6 +25,7 @@ repositories {
     maven("https://repo.fancyplugins.de/releases/")
     maven("https://repo.spongepowered.org/maven/")
     maven("https://repo.extendedclip.com/content/repositories/placeholderapi/")
+    maven("https://repo.bg-software.com/repository/api/")
     mavenLocal()
     mavenCentral()
 }
@@ -45,6 +46,7 @@ dependencies {
     compileOnly("io.github.fabiozumbi12.RedProtect:RedProtect-Core:8.1.2"){ exclude(group = "*") }
     compileOnly("io.github.fabiozumbi12.RedProtect:RedProtect-Spigot:8.1.2"){ exclude(group = "*") }
     compileOnly("me.clip:placeholderapi:2.11.6")
+    compileOnly("com.bgsoftware:SuperiorSkyblockAPI:2024.4")
 
     compileOnly("com.github.decentsoftware-eu:decentholograms:2.8.3")
     compileOnly("de.oliver:FancyHolograms:2.0.6")

--- a/src/main/java/com/lkeehl/elevators/helpers/InventoryHelper.java
+++ b/src/main/java/com/lkeehl/elevators/helpers/InventoryHelper.java
@@ -138,6 +138,15 @@ public class InventoryHelper {
     }
 
     public static void openInteractNameMenu(Player player, Elevator elevator) {
+        List<ProtectionHook> hooks = HookService.getProtectionHooks();
+        for(ProtectionHook hook : hooks) {
+            if(!hook.canEditName(player, elevator, true)) {
+                player.closeInventory(InventoryCloseEvent.Reason.CANT_USE);
+                ElevatorHelper.setElevatorEnabled(elevator.getShulkerBox());
+                ShulkerBoxHelper.playClose(elevator.getShulkerBox());
+                return;
+            }
+        }
         String currentName = DataContainerService.getFloorName(elevator);
         try {
             SignGUIBuilder builder = SignGUI.builder();
@@ -171,6 +180,15 @@ public class InventoryHelper {
     }
 
     public static void openInteractSettingsMenu(Player player, Elevator elevator) {
+        List<ProtectionHook> hooks = HookService.getProtectionHooks();
+        for(ProtectionHook hook : hooks) {
+            if(!hook.canEditSettings(player, elevator, true)) {
+                player.closeInventory(InventoryCloseEvent.Reason.CANT_USE);
+                ElevatorHelper.setElevatorEnabled(elevator.getShulkerBox());
+                ShulkerBoxHelper.playClose(elevator.getShulkerBox());
+                return;
+            }
+        }
         List<ElevatorSetting<?>> settings = ElevatorSettingService.getElevatorSettings().stream().filter(i -> i.canBeEditedIndividually(elevator)).toList();
 
         int inventorySize = (Math.floorDiv(settings.size() + 8, 9) * 9) + 9;

--- a/src/main/java/com/lkeehl/elevators/models/hooks/ProtectionHook.java
+++ b/src/main/java/com/lkeehl/elevators/models/hooks/ProtectionHook.java
@@ -38,4 +38,7 @@ public abstract class ProtectionHook implements ElevatorHook {
 
     public abstract void onProtectionClick(Player player, Elevator elevator, Runnable onReturn);
 
+    public abstract boolean canEditName(Player player, Elevator elevator, boolean sendMessage);
+
+    public abstract boolean canEditSettings(Player player, Elevator elevator, boolean sendMessage);
 }

--- a/src/main/java/com/lkeehl/elevators/services/HookService.java
+++ b/src/main/java/com/lkeehl/elevators/services/HookService.java
@@ -41,23 +41,26 @@ public class HookService {
 
     private static void buildHooks() {
 
-        HookService.registerHookIfPluginActive("GriefPrevention", GriefPreventionHook.class);
-        HookService.registerHookIfPluginActive("GriefDefender", GriefDefenderHook.class);
-        HookService.registerHookIfPluginActive("RedProtect", RedProtectHook.class);
-        HookService.registerHookIfPluginActive("PlotSquared", PlotSquaredHook.class);
-        HookService.registerHookIfPluginActive("BentoBox", BentoBoxHook.class);
-        HookService.registerHookIfPluginActive("PlaceholderAPI", PlaceholderAPIHook.class);
-        HookService.registerHookIfPluginActive("DecentHolograms", DecentHologramsHook.class);
-        HookService.registerHookIfPluginActive("FancyHolograms", FancyHologramsHook.class);
-        HookService.registerHookIfPluginActive("SuperiorSkyblock2", SuperiorSkyblock2Hook.class);
+        HookService.registerHookIfPluginActive("GriefPrevention", false, GriefPreventionHook.class);
+        HookService.registerHookIfPluginActive("GriefDefender", false, GriefDefenderHook.class);
+        HookService.registerHookIfPluginActive("RedProtect", false, RedProtectHook.class);
+        HookService.registerHookIfPluginActive("PlotSquared", false, PlotSquaredHook.class);
+        HookService.registerHookIfPluginActive("BentoBox", false, BentoBoxHook.class);
+        HookService.registerHookIfPluginActive("PlaceholderAPI", false, PlaceholderAPIHook.class);
+        HookService.registerHookIfPluginActive("DecentHolograms", false, DecentHologramsHook.class);
+        HookService.registerHookIfPluginActive("FancyHolograms", false, FancyHologramsHook.class);
+        HookService.registerHookIfPluginActive("SuperiorSkyblock2", true, SuperiorSkyblock2Hook.class);
     }
 
-    public static boolean registerHookIfPluginActive(String pluginName, Class<? extends ElevatorHook> elevatorHookClass) {
+    public static boolean registerHookIfPluginActive(String pluginName, boolean needOnlyLoad, Class<? extends ElevatorHook> elevatorHookClass) {
        if(hookMap.containsKey(pluginName.toUpperCase()))
            return true;
 
-       if(!Bukkit.getPluginManager().isPluginEnabled(pluginName))
-           return false;
+       if(needOnlyLoad) {
+           if(Bukkit.getPluginManager().getPlugin(pluginName) == null) return false;
+       } else {
+           if(!Bukkit.getPluginManager().isPluginEnabled(pluginName)) return false;
+       }
 
         try {
             Constructor<?> hookConstructor = elevatorHookClass.getConstructor();
@@ -117,8 +120,13 @@ public class HookService {
     @SuppressWarnings("unchecked")
     public static <T extends ElevatorHook> T getHook(String hookKey, Class<T> hookClazz) {
         hookKey = hookKey.toUpperCase();
-        if(!hookMap.containsKey(hookKey.toUpperCase()) && !HookService.registerHookIfPluginActive(hookKey, hookClazz))
-            return null;
+        if(!hookMap.containsKey(hookKey.toUpperCase())) {
+            if (hookKey.equals("SUPERIORSKYBLOCK2")) {
+                if(!HookService.registerHookIfPluginActive(hookKey, true, hookClazz)) return null;
+            } else {
+                if(!HookService.registerHookIfPluginActive(hookKey, false, hookClazz)) return null;
+            }
+        }
 
         return (T) hookMap.get(hookKey);
     }

--- a/src/main/java/com/lkeehl/elevators/services/HookService.java
+++ b/src/main/java/com/lkeehl/elevators/services/HookService.java
@@ -49,7 +49,7 @@ public class HookService {
         HookService.registerHookIfPluginActive("PlaceholderAPI", PlaceholderAPIHook.class);
         HookService.registerHookIfPluginActive("DecentHolograms", DecentHologramsHook.class);
         HookService.registerHookIfPluginActive("FancyHolograms", FancyHologramsHook.class);
-
+        HookService.registerHookIfPluginActive("SuperiorSkyblock2", SuperiorSkyblock2Hook.class);
     }
 
     public static boolean registerHookIfPluginActive(String pluginName, Class<? extends ElevatorHook> elevatorHookClass) {
@@ -92,6 +92,10 @@ public class HookService {
 
     public static BentoBoxHook getBentoBoxHook() {
         return getHook("BentoBox", BentoBoxHook.class);
+    }
+
+    public static SuperiorSkyblock2Hook getSuperiorSkyblock2Hook() {
+        return getHook("SuperiorSkyblock2", SuperiorSkyblock2Hook.class);
     }
 
     public static PlaceholderAPIHook getPlaceholderAPIHook() {

--- a/src/main/java/com/lkeehl/elevators/services/ListenerService.java
+++ b/src/main/java/com/lkeehl/elevators/services/ListenerService.java
@@ -49,7 +49,7 @@ public class ListenerService {
         registerEventExecutor(EntityExplodeEvent.class, EventPriority.NORMAL , WorldEventExecutor::onExplode);
         registerEventExecutor(BlockDispenseEvent.class, EventPriority.NORMAL , WorldEventExecutor::onDispenserPlace);
         registerEventExecutor(BlockDropItemEvent.class, EventPriority.LOWEST , WorldEventExecutor::onBlockBreak);
-        registerEventExecutor(BlockPlaceEvent.class, EventPriority.NORMAL , WorldEventExecutor::onBlockPlace);
+        registerEventExecutor(BlockPlaceEvent.class, EventPriority.HIGHEST , WorldEventExecutor::onBlockPlace);
 
         registerEventExecutor(PlayerJoinEvent.class, EventPriority.NORMAL, EntityEventExecutor::onJoin);
         registerEventExecutor(PlayerToggleSneakEvent.class, EventPriority.NORMAL , EntityEventExecutor::onSneak);

--- a/src/main/java/com/lkeehl/elevators/services/hooks/BentoBoxHook.java
+++ b/src/main/java/com/lkeehl/elevators/services/hooks/BentoBoxHook.java
@@ -20,19 +20,31 @@ import java.util.List;
 import java.util.Locale;
 
 public class BentoBoxHook extends ProtectionHook {
-
-    Flag flag;
+    //TODO: Code cleanup
+    Flag useFlag, editNameFlag, editSettingsFlag;
 
     public BentoBoxHook() {
         super("BentoBox");
 
-        this.flag = (new Flag.Builder("USE_ELEVATOR", Material.RED_SHULKER_BOX)).mode(Flag.Mode.BASIC).build();
-        BentoBox.getInstance().getFlagsManager().registerFlag(this.flag);
+        this.useFlag = (new Flag.Builder("USE_ELEVATOR", Material.RED_SHULKER_BOX)).mode(Flag.Mode.BASIC).build();
+        BentoBox.getInstance().getFlagsManager().registerFlag(this.useFlag);
+        this.editNameFlag = (new Flag.Builder("EDIT_ELEVATOR_FLOOR_NAME", Material.RED_SHULKER_BOX)).mode(Flag.Mode.BASIC).build();
+        BentoBox.getInstance().getFlagsManager().registerFlag(this.editNameFlag);
+        this.editSettingsFlag = (new Flag.Builder("EDIT_ELEVATOR_SETTINGS", Material.RED_SHULKER_BOX)).mode(Flag.Mode.BASIC).build();
+        BentoBox.getInstance().getFlagsManager().registerFlag(this.editSettingsFlag);
         for (Locale objLocale : BentoBox.getInstance().getLocalesManager().getAvailableLocales(true)) {
             BentoBoxLocale locale = BentoBox.getInstance().getLocalesManager().getLanguages().get(objLocale);
             if (!locale.contains("protection.flags.USE_ELEVATOR.name")) {
                 locale.set("protection.flags.USE_ELEVATOR.name", "Use elevators");
                 locale.set("protection.flags.USE_ELEVATOR.description", "Toggle elevators");
+            }
+            if(!locale.contains("protection.flags.EDIT_ELEVATOR_FLOOR_NAME.name")) {
+                locale.set("protection.flags.EDIT_ELEVATOR_FLOOR_NAME.name", "Edit Elevator floor name");
+                locale.set("protection.flags.EDIT_ELEVATOR_FLOOR_NAME.description", "Edit the name of the Elevator floor");
+            }
+            if(!locale.contains("protection.flags.EDIT_ELEVATOR_SETTINGS.name")) {
+                locale.set("protection.flags.EDIT_ELEVATOR_SETTINGS.name", "Edit Elevators settings");
+                locale.set("protection.flags.EDIT_ELEVATOR_SETTINGS.description", "Edit the settings of the Elevators");
             }
         }
     }
@@ -54,7 +66,7 @@ public class BentoBoxHook extends ProtectionHook {
 
         User user = BentoBox.getInstance().getPlayers().getUser(player.getUniqueId());
 
-        if(island.isAllowed(user, this.flag))
+        if(island.isAllowed(user, this.useFlag))
             return true;
 
         if(sendMessage)
@@ -85,5 +97,43 @@ public class BentoBoxHook extends ProtectionHook {
     public void onProtectionClick(Player player, Elevator elevator, Runnable onReturn) {
         this.toggleAllowMemberUse(elevator);
         onReturn.run();
+    }
+
+    @Override
+    public boolean canEditName(Player player, Elevator elevator, boolean sendMessage) {
+        Location location = elevator.getLocation();
+        Island island = BentoBox.getInstance().getIslands().getIslandAt(location).orElse(null);
+        if (island == null)
+            return true;
+        if (!island.getProtectionBoundingBox().contains(location.getX(), location.getY(), location.getZ()))
+            return true;
+
+        User user = BentoBox.getInstance().getPlayers().getUser(player.getUniqueId());
+
+        if(island.isAllowed(user, this.editNameFlag))
+            return true;
+
+        if(sendMessage)
+            user.sendMessage("general.errors.insufficient-rank", TextVariables.RANK, user.getTranslation(BentoBox.getInstance().getRanksManager().getRank(island.getRank(user))));
+        return false;
+    }
+
+    @Override
+    public boolean canEditSettings(Player player, Elevator elevator, boolean sendMessage) {
+        Location location = elevator.getLocation();
+        Island island = BentoBox.getInstance().getIslands().getIslandAt(location).orElse(null);
+        if (island == null)
+            return true;
+        if (!island.getProtectionBoundingBox().contains(location.getX(), location.getY(), location.getZ()))
+            return true;
+
+        User user = BentoBox.getInstance().getPlayers().getUser(player.getUniqueId());
+
+        if(island.isAllowed(user, this.editSettingsFlag))
+            return true;
+
+        if(sendMessage)
+            user.sendMessage("general.errors.insufficient-rank", TextVariables.RANK, user.getTranslation(BentoBox.getInstance().getRanksManager().getRank(island.getRank(user))));
+        return false;
     }
 }

--- a/src/main/java/com/lkeehl/elevators/services/hooks/GriefDefenderHook.java
+++ b/src/main/java/com/lkeehl/elevators/services/hooks/GriefDefenderHook.java
@@ -16,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class GriefDefenderHook extends ProtectionHook {
-
+    //TODO: Add in the configs the option for select the minimium rank for edit name and settings
     public GriefDefenderHook() {
         super("GriefDefender");
     }
@@ -57,5 +57,29 @@ public class GriefDefenderHook extends ProtectionHook {
     public void onProtectionClick(Player player, Elevator elevator, Runnable onReturn) {
         this.toggleAllowMemberUse(elevator);
         onReturn.run();
+    }
+
+    @Override
+    public boolean canEditName(Player player, Elevator elevator, boolean sendMessage) {
+        ShulkerBox box = elevator.getShulkerBox();
+        final Claim claim = GriefDefender.getCore().getClaimAt(elevator.getLocation());
+
+        if (claim == null) //The elevator can be in the spawn
+            return false;
+        if(claim.isWilderness())
+            return true;
+        return claim.canUseBlock(elevator.getShulkerBox(), elevator.getLocation(), GriefDefender.getCore().getUser(player.getUniqueId()), TrustTypes.ACCESSOR);
+    }
+
+    @Override
+    public boolean canEditSettings(Player player, Elevator elevator, boolean sendMessage) {
+        ShulkerBox box = elevator.getShulkerBox();
+        final Claim claim = GriefDefender.getCore().getClaimAt(elevator.getLocation());
+
+        if (claim == null) //The elevator can be in the spawn
+            return false;
+        if(claim.isWilderness())
+            return true;
+        return claim.canUseBlock(elevator.getShulkerBox(), elevator.getLocation(), GriefDefender.getCore().getUser(player.getUniqueId()), TrustTypes.MANAGER);
     }
 }

--- a/src/main/java/com/lkeehl/elevators/services/hooks/GriefPreventionHook.java
+++ b/src/main/java/com/lkeehl/elevators/services/hooks/GriefPreventionHook.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class GriefPreventionHook extends ProtectionHook {
-
+    //TODO: Add in the configs the option for select the minimium rank for edit name and settings
     private final GriefPrevention griefPrevention;
 
     public GriefPreventionHook() {
@@ -73,5 +73,35 @@ public class GriefPreventionHook extends ProtectionHook {
     public void onProtectionClick(Player player, Elevator elevator, Runnable onReturn) {
         this.toggleAllowMemberUse(elevator);
         onReturn.run();
+    }
+
+    @Override
+    public boolean canEditName(Player player, Elevator elevator, boolean sendMessage) {
+        if(this.griefPrevention == null)
+            return false;
+        PlayerData playerData = this.griefPrevention.dataStore.getPlayerData(player.getUniqueId());
+        Claim claim = this.griefPrevention.dataStore.getClaimAt(elevator.getLocation(), false, playerData.lastClaim);
+        Supplier<String> message = claim.checkPermission(player, ClaimPermission.Edit, null);
+        if(message != null) {
+            if(sendMessage)
+                player.sendMessage(ChatColor.RED + message.get());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean canEditSettings(Player player, Elevator elevator, boolean sendMessage) {
+        if(this.griefPrevention == null)
+            return false;
+        PlayerData playerData = this.griefPrevention.dataStore.getPlayerData(player.getUniqueId());
+        Claim claim = this.griefPrevention.dataStore.getClaimAt(elevator.getLocation(), false, playerData.lastClaim);
+        Supplier<String> message = claim.checkPermission(player, ClaimPermission.Manage, null);
+        if(message != null) {
+            if(sendMessage)
+                player.sendMessage(ChatColor.RED + message.get());
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/com/lkeehl/elevators/services/hooks/PlotSquaredHook.java
+++ b/src/main/java/com/lkeehl/elevators/services/hooks/PlotSquaredHook.java
@@ -20,13 +20,17 @@ import java.util.List;
 // Gotta be honest, I think that PlotSquared has one of the most inconvenient and convoluted flag systems ever.
 public class PlotSquaredHook extends ProtectionHook {
 
-    private final ElevatorFlag flag;
+    private final ElevatorUseFlag useFlag;
+    private final ElevatorEditNameFlag nameFlag;
+    private final ElevatorEditSettingsFlag settingsFlag;
 
     private final PlotAPI api;
 
     public PlotSquaredHook() {
         super("PlotSquared");
-        GlobalFlagContainer.getInstance().addFlag(this.flag = new ElevatorFlag(true));
+        GlobalFlagContainer.getInstance().addFlag(this.useFlag = new ElevatorUseFlag(true));
+        GlobalFlagContainer.getInstance().addFlag(this.nameFlag = new ElevatorEditNameFlag(true));
+        GlobalFlagContainer.getInstance().addFlag(this.settingsFlag = new ElevatorEditSettingsFlag(false));
 
         this.api = new PlotAPI();
     }
@@ -40,7 +44,7 @@ public class PlotSquaredHook extends ProtectionHook {
         if(plotPlayer == null)
             return false;
         Plot currentPlot = plotPlayer.getCurrentPlot();
-        if(currentPlot == null || currentPlot.getFlag(flag))
+        if(currentPlot == null || currentPlot.getFlag(useFlag))
             return true;
 
         if(currentPlot.getTrusted().contains(player.getUniqueId()))
@@ -80,15 +84,75 @@ public class PlotSquaredHook extends ProtectionHook {
         onReturn.run();
     }
 
-    public static class ElevatorFlag extends BooleanFlag<ElevatorFlag> {
+    @Override
+    public boolean canEditName(Player player, Elevator elevator, boolean sendMessage) {
+        PlotPlayer<?> plotPlayer = this.api.wrapPlayer(player.getUniqueId());
+        if(plotPlayer == null)
+            return false;
+        Plot currentPlot = plotPlayer.getCurrentPlot();
+        if(currentPlot == null || currentPlot.getFlag(nameFlag))
+            return true;
 
-        protected ElevatorFlag(boolean value) {
+        if(currentPlot.getTrusted().contains(player.getUniqueId()))
+            return true;
+
+        if(currentPlot.getMembers().contains(player.getUniqueId()))
+            return true;
+
+        return currentPlot.getOwners().contains(player.getUniqueId());
+    }
+
+    @Override
+    public boolean canEditSettings(Player player, Elevator elevator, boolean sendMessage) {
+        PlotPlayer<?> plotPlayer = this.api.wrapPlayer(player.getUniqueId());
+        if(plotPlayer == null)
+            return false;
+        Plot currentPlot = plotPlayer.getCurrentPlot();
+        if(currentPlot == null || currentPlot.getFlag(settingsFlag))
+            return true;
+
+        if(currentPlot.getTrusted().contains(player.getUniqueId()))
+            return true;
+
+        if(currentPlot.getMembers().contains(player.getUniqueId()))
+            return true;
+
+        return currentPlot.getOwners().contains(player.getUniqueId());
+    }
+
+    public static class ElevatorUseFlag extends BooleanFlag<ElevatorUseFlag> {
+
+        protected ElevatorUseFlag(boolean value) {
             super(value, TranslatableCaption.of("flags.guest_elevators"));
         }
 
         @Override
-        protected ElevatorFlag flagOf(Boolean aBoolean) {
-            return new ElevatorFlag(aBoolean);
+        protected ElevatorUseFlag flagOf(Boolean aBoolean) {
+            return new ElevatorUseFlag(aBoolean);
+        }
+    }
+
+    public static class ElevatorEditNameFlag extends BooleanFlag<ElevatorEditNameFlag> {
+
+        protected ElevatorEditNameFlag(boolean value) {
+            super(value, TranslatableCaption.of("flags.name_elevators"));
+        }
+
+        @Override
+        protected ElevatorEditNameFlag flagOf(Boolean aBoolean) {
+            return new ElevatorEditNameFlag(aBoolean);
+        }
+    }
+
+    public static class ElevatorEditSettingsFlag extends BooleanFlag<ElevatorEditSettingsFlag> {
+
+        protected ElevatorEditSettingsFlag(boolean value) {
+            super(value, TranslatableCaption.of("flags.settings_elevators"));
+        }
+
+        @Override
+        protected ElevatorEditSettingsFlag flagOf(Boolean aBoolean) {
+            return new ElevatorEditSettingsFlag(aBoolean);
         }
     }
 

--- a/src/main/java/com/lkeehl/elevators/services/hooks/RedProtectHook.java
+++ b/src/main/java/com/lkeehl/elevators/services/hooks/RedProtectHook.java
@@ -15,16 +15,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class RedProtectHook extends ProtectionHook {
-
+    //TODO: Code cleanup
     private final RedProtectAPI redProtect;
 
     private final String flagName = "outsiders-use-elevators";
+    private final String nameFlagName = "edit-name-elevators";
+    private final String settingsFlagName = "edit-settings-elevators";
 
     public RedProtectHook() {
         super("RedProtect");
         this.redProtect = RedProtect.get().getAPI();
 
-        this.redProtect.addFlag("use-elevators", true, false);
+        this.redProtect.addFlag(flagName, true, false);
+        this.redProtect.addFlag(nameFlagName, true, false);
+        this.redProtect.addFlag(settingsFlagName, false, false);
     }
 
     @Override
@@ -33,7 +37,7 @@ public class RedProtectHook extends ProtectionHook {
             return true;
 
         Region region = redProtect.getRegion(elevator.getShulkerBox().getLocation());
-        if(region == null || region.getFlagBool("outsiders-use-elevators"))
+        if(region == null || region.getFlagBool(flagName))
             return true;
 
         if(region.isLeader(player) || region.isAdmin(player) || region.isMember(player) || player.hasPermission("redprotect.flag.bypass." + this.flagName))
@@ -66,5 +70,33 @@ public class RedProtectHook extends ProtectionHook {
     public void onProtectionClick(Player player, Elevator elevator, Runnable onReturn) {
         this.toggleAllowMemberUse(elevator);
         onReturn.run();
+    }
+
+    @Override
+    public boolean canEditName(Player player, Elevator elevator, boolean sendMessage) {
+        Region region = redProtect.getRegion(elevator.getShulkerBox().getLocation());
+        if(region == null || region.getFlagBool(nameFlagName))
+            return true;
+
+        if(region.isLeader(player) || region.isAdmin(player) || region.isMember(player) || player.hasPermission("redprotect.flag.bypass." + this.nameFlagName))
+            return true;
+
+        if(sendMessage)
+            player.sendMessage(ChatColor.RED + "You can't interact with this here!");
+        return false;
+    }
+
+    @Override
+    public boolean canEditSettings(Player player, Elevator elevator, boolean sendMessage) {
+        Region region = redProtect.getRegion(elevator.getShulkerBox().getLocation());
+        if(region == null || region.getFlagBool(settingsFlagName))
+            return true;
+
+        if(region.isLeader(player) || region.isAdmin(player) || player.hasPermission("redprotect.flag.bypass." + this.settingsFlagName))
+            return true;
+
+        if(sendMessage)
+            player.sendMessage(ChatColor.RED + "You can't interact with this here!");
+        return false;
     }
 }

--- a/src/main/java/com/lkeehl/elevators/services/hooks/SuperiorSkyblock2Hook.java
+++ b/src/main/java/com/lkeehl/elevators/services/hooks/SuperiorSkyblock2Hook.java
@@ -1,0 +1,112 @@
+package com.lkeehl.elevators.services.hooks;
+
+import com.bgsoftware.superiorskyblock.api.SuperiorSkyblockAPI;
+import com.bgsoftware.superiorskyblock.api.island.Island;
+import com.bgsoftware.superiorskyblock.api.island.IslandPrivilege;
+import com.lkeehl.elevators.Elevators;
+import com.lkeehl.elevators.helpers.ItemStackHelper;
+import com.lkeehl.elevators.models.Elevator;
+import com.lkeehl.elevators.models.hooks.ProtectionHook;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SuperiorSkyblock2Hook extends ProtectionHook {
+
+    private static final String USE_ELEVATOR_FLAG = "elevators_use";
+    private static final String EDIT_NAME_ELEVATOR_FLAG = "elevators_edit_name";
+    private static final String EDIT_SETTINGS_ELEVATOR_FLAG = "elevators_edit_settings";
+
+    private static IslandPrivilege USE_ELEVATOR, EDIT_NAME_ELEVATOR, EDIT_SETTINGS_ELEVATOR;
+    private static boolean registered = false;
+
+    public SuperiorSkyblock2Hook() {
+        super("SuperiorSkyblock2");
+        register();
+    }
+
+    public static void register() {
+        if (registered)
+            return;
+
+        try {
+            USE_ELEVATOR = IslandPrivilege.getByName(USE_ELEVATOR_FLAG);
+            EDIT_NAME_ELEVATOR = IslandPrivilege.getByName(EDIT_NAME_ELEVATOR_FLAG);
+            EDIT_SETTINGS_ELEVATOR = IslandPrivilege.getByName(EDIT_SETTINGS_ELEVATOR_FLAG);
+        } catch(NullPointerException e) {
+            IslandPrivilege.register(USE_ELEVATOR_FLAG);
+            IslandPrivilege.register(EDIT_NAME_ELEVATOR_FLAG);
+            IslandPrivilege.register(EDIT_SETTINGS_ELEVATOR_FLAG);
+            try {
+                USE_ELEVATOR = IslandPrivilege.getByName(USE_ELEVATOR_FLAG);
+                EDIT_NAME_ELEVATOR = IslandPrivilege.getByName(EDIT_NAME_ELEVATOR_FLAG);
+                EDIT_SETTINGS_ELEVATOR = IslandPrivilege.getByName(EDIT_SETTINGS_ELEVATOR_FLAG);
+            } catch(Exception ex) {
+                Elevators.getElevatorsLogger().severe("Failed to register SuperiorSkyblock Hook - please open a issue on Github");
+                e.printStackTrace();
+                return;
+            }
+        }
+        registered = true;
+    }
+
+    @Override
+    public boolean canPlayerUseElevator(Player player, Elevator elevator, boolean sendMessage) {
+        if(!registered) return true;
+        Island island = SuperiorSkyblockAPI.getIslandAt(elevator.getLocation());
+        if (island != null) {
+            return island.hasPermission(SuperiorSkyblockAPI.getPlayer(player.getUniqueId()), USE_ELEVATOR);
+        }
+        return true;
+    }
+
+    @Override
+    public ItemStack createIconForElevator(Player player, Elevator elevator) {
+        if(!registered) return null;
+        Island island = SuperiorSkyblockAPI.getIslandAt(elevator.getLocation());
+        if(island == null)
+            return null;
+
+        boolean flagEnabled = this.shouldAllowGuestUse(elevator);
+
+        List<String> lore = new ArrayList<>();
+        lore.add("");
+        lore.add(ChatColor.GRAY + "Controls whether non-members");
+        lore.add(ChatColor.GRAY + "can use this elevator.");
+        lore.add("");
+        lore.add(ChatColor.GRAY + "Status: ");
+        lore.add(flagEnabled ? (ChatColor.GREEN + "" + ChatColor.BOLD + "ENABLED") : (ChatColor.RED + "" + ChatColor.BOLD + "DISABLED") );
+
+        return ItemStackHelper.createItem(ChatColor.GREEN + "" + ChatColor.BOLD + "SuperiorSkyblock2", Material.DIAMOND, 1, lore);
+    }
+
+    @Override
+    public void onProtectionClick(Player player, Elevator elevator, Runnable onReturn) {
+        this.toggleAllowMemberUse(elevator);
+        onReturn.run();
+    }
+
+    @Override
+    public boolean canEditName(Player player, Elevator elevator, boolean sendMessage) {
+        if(!registered) return true;
+        Island island = SuperiorSkyblockAPI.getIslandAt(elevator.getLocation());
+        if (island != null) {
+            return island.hasPermission(SuperiorSkyblockAPI.getPlayer(player.getUniqueId()), EDIT_NAME_ELEVATOR);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean canEditSettings(Player player, Elevator elevator, boolean sendMessage) {
+        if(!registered) return true;
+        Island island = SuperiorSkyblockAPI.getIslandAt(elevator.getLocation());
+        if (island != null) {
+            return island.hasPermission(SuperiorSkyblockAPI.getPlayer(player.getUniqueId()), EDIT_SETTINGS_ELEVATOR);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/lkeehl/elevators/services/hooks/SuperiorSkyblock2Hook.java
+++ b/src/main/java/com/lkeehl/elevators/services/hooks/SuperiorSkyblock2Hook.java
@@ -1,6 +1,7 @@
 package com.lkeehl.elevators.services.hooks;
 
 import com.bgsoftware.superiorskyblock.api.SuperiorSkyblockAPI;
+import com.bgsoftware.superiorskyblock.api.events.PluginInitializeEvent;
 import com.bgsoftware.superiorskyblock.api.island.Island;
 import com.bgsoftware.superiorskyblock.api.island.IslandPrivilege;
 import com.lkeehl.elevators.Elevators;
@@ -10,12 +11,14 @@ import com.lkeehl.elevators.models.hooks.ProtectionHook;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class SuperiorSkyblock2Hook extends ProtectionHook {
+public class SuperiorSkyblock2Hook extends ProtectionHook implements Listener {
 
     private static final String USE_ELEVATOR_FLAG = "elevators_use";
     private static final String EDIT_NAME_ELEVATOR_FLAG = "elevators_edit_name";
@@ -26,32 +29,24 @@ public class SuperiorSkyblock2Hook extends ProtectionHook {
 
     public SuperiorSkyblock2Hook() {
         super("SuperiorSkyblock2");
-        register();
+        if(!registered) Elevators.getInstance().getServer().getPluginManager().registerEvents(this, Elevators.getInstance());
     }
 
-    public static void register() {
-        if (registered)
-            return;
-
+    @EventHandler
+    public void onSSB2Enable(PluginInitializeEvent e) {
         try {
-            USE_ELEVATOR = IslandPrivilege.getByName(USE_ELEVATOR_FLAG);
-            EDIT_NAME_ELEVATOR = IslandPrivilege.getByName(EDIT_NAME_ELEVATOR_FLAG);
-            EDIT_SETTINGS_ELEVATOR = IslandPrivilege.getByName(EDIT_SETTINGS_ELEVATOR_FLAG);
-        } catch(NullPointerException e) {
             IslandPrivilege.register(USE_ELEVATOR_FLAG);
             IslandPrivilege.register(EDIT_NAME_ELEVATOR_FLAG);
             IslandPrivilege.register(EDIT_SETTINGS_ELEVATOR_FLAG);
-            try {
-                USE_ELEVATOR = IslandPrivilege.getByName(USE_ELEVATOR_FLAG);
-                EDIT_NAME_ELEVATOR = IslandPrivilege.getByName(EDIT_NAME_ELEVATOR_FLAG);
-                EDIT_SETTINGS_ELEVATOR = IslandPrivilege.getByName(EDIT_SETTINGS_ELEVATOR_FLAG);
-            } catch(Exception ex) {
-                Elevators.getElevatorsLogger().severe("Failed to register SuperiorSkyblock Hook - please open a issue on Github");
-                e.printStackTrace();
-                return;
-            }
+            USE_ELEVATOR = IslandPrivilege.getByName(USE_ELEVATOR_FLAG);
+            EDIT_NAME_ELEVATOR = IslandPrivilege.getByName(EDIT_NAME_ELEVATOR_FLAG);
+            EDIT_SETTINGS_ELEVATOR = IslandPrivilege.getByName(EDIT_SETTINGS_ELEVATOR_FLAG);
+            Elevators.getElevatorsLogger().info("Hooked into SuperiorSkyblock2 correctly");
+            registered = true;
+        } catch(Exception ex) {
+            Elevators.getElevatorsLogger().severe("Failed to register SuperiorSkyblock Hook - please open a issue on Github");
+            ex.printStackTrace();
         }
-        registered = true;
     }
 
     @Override

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,8 @@ version: 5.0.0
 author: Keehl
 main: com.lkeehl.elevators.Elevators
 api-version: 1.13
-softdepend: [SuperiorSkyblock2,PlaceholderAPI,RedProtect,Vault,HolographicDisplays,GriefPrevention,GriefDefender,CMI,PlotSquared,BentoBox,DecentHolograms,FancyHolograms,ProtocolLib]
+loadbefore: [SuperiorSkyblock2]
+softdepend: [PlaceholderAPI,RedProtect,Vault,HolographicDisplays,GriefPrevention,GriefDefender,CMI,PlotSquared,BentoBox,DecentHolograms,FancyHolograms,ProtocolLib]
 
 commands:
   elevators:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: 5.0.0
 author: Keehl
 main: com.lkeehl.elevators.Elevators
 api-version: 1.13
-softdepend: [PlaceholderAPI,RedProtect,Vault,HolographicDisplays,GriefPrevention,GriefDefender,CMI,PlotSquared,BentoBox,DecentHolograms,FancyHolograms,ProtocolLib]
+softdepend: [SuperiorSkyblock2,PlaceholderAPI,RedProtect,Vault,HolographicDisplays,GriefPrevention,GriefDefender,CMI,PlotSquared,BentoBox,DecentHolograms,FancyHolograms,ProtocolLib]
 
 commands:
   elevators:


### PR DESCRIPTION
Hi!
I’ve developed the SuperiorSkyblock2 (SSB2) hook, as mentioned in the previous PR.
I’ve also added the new methods to all protection hooks, although I’ve only tested the implementation with SSB2 for now.
I've also changed BlockPlaceEvent priority because some plugins handle this after the amount change and, if the amount is 1, the item became null for other plugins.
Additionally, I’ve found a bug that occurs on plugin/server reload:
If a player has an elevator gui open during the reload, the elevator ends up broken afterward.
Do you have any ideas on how to fix this?
