### PR TITLE
Optimized Holograms for Paper and fixed Paper detection

### DIFF
--- a/src/main/java/com/lkeehl/elevators/Elevators.java
+++ b/src/main/java/com/lkeehl/elevators/Elevators.java
@@ -30,7 +30,6 @@ public class Elevators extends JavaPlugin {
         ElevatorTypeService.init();
         ElevatorRecipeService.init();
         ElevatorObstructionService.init();
-        ElevatorHookService.initPaperDetection();
         ElevatorListenerService.init();
         ElevatorHookService.init();
         ElevatorHologramService.init();

--- a/src/main/java/com/lkeehl/elevators/Elevators.java
+++ b/src/main/java/com/lkeehl/elevators/Elevators.java
@@ -1,5 +1,6 @@
 package com.lkeehl.elevators;
 
+import com.lkeehl.elevators.models.hooks.ElevatorHook;
 import com.lkeehl.elevators.services.*;
 import com.tcoded.folialib.FoliaLib;
 import org.bukkit.Bukkit;
@@ -29,8 +30,9 @@ public class Elevators extends JavaPlugin {
         ElevatorTypeService.init();
         ElevatorRecipeService.init();
         ElevatorObstructionService.init();
-        ElevatorHookService.init();
+        ElevatorHookService.initPaperDetection();
         ElevatorListenerService.init();
+        ElevatorHookService.init();
         ElevatorHologramService.init();
         ElevatorCommandService.init(this);
 

--- a/src/main/java/com/lkeehl/elevators/Elevators.java
+++ b/src/main/java/com/lkeehl/elevators/Elevators.java
@@ -29,8 +29,8 @@ public class Elevators extends JavaPlugin {
         ElevatorTypeService.init();
         ElevatorRecipeService.init();
         ElevatorObstructionService.init();
-        ElevatorListenerService.init();
         ElevatorHookService.init();
+        ElevatorListenerService.init();
         ElevatorHologramService.init();
         ElevatorCommandService.init(this);
 

--- a/src/main/java/com/lkeehl/elevators/helpers/ItemStackHelper.java
+++ b/src/main/java/com/lkeehl/elevators/helpers/ItemStackHelper.java
@@ -9,6 +9,7 @@ import com.lkeehl.elevators.services.ElevatorDataContainerService;
 import com.lkeehl.elevators.services.ElevatorSettingService;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -23,7 +24,7 @@ public class ItemStackHelper {
     private static final Pattern dyeColorPattern = Pattern.compile("(?:LIGHT_)?.+?(?=_)");
 
     public static boolean isNotShulkerBox(Material type) {
-        return !type.toString().endsWith("SHULKER_BOX");
+        return !Tag.SHULKER_BOXES.isTagged(type);
     }
 
     public static DyeColor getDyeColorFromMaterial(Material material) {

--- a/src/main/java/com/lkeehl/elevators/models/ElevatorType.java
+++ b/src/main/java/com/lkeehl/elevators/models/ElevatorType.java
@@ -1,19 +1,18 @@
 package com.lkeehl.elevators.models;
 
 import com.lkeehl.elevators.Elevators;
-import com.lkeehl.elevators.helpers.ElevatorHelper;
 import com.lkeehl.elevators.services.ElevatorActionService;
 import com.lkeehl.elevators.services.ElevatorHologramService;
 import com.lkeehl.elevators.services.configs.ConfigElevatorType;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.World;
-import org.bukkit.block.BlockState;
-import org.bukkit.block.ShulkerBox;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import static com.lkeehl.elevators.services.ElevatorHologramService.updateElevatorHologramsInChunk;
 
 public class ElevatorType extends ConfigElevatorType {
 
@@ -265,18 +264,9 @@ public class ElevatorType extends ConfigElevatorType {
 
         // Oof, this is a lot of nesting. Hate that, but don't want to extract to a method.
         Elevators.getFoliaLib().getScheduler().runNextTick(task -> {
-            for(World world : Bukkit.getWorlds()) {
-                for(Chunk chunk : world.getLoadedChunks()) {
-                    for (BlockState state : chunk.getTileEntities()) {
-                        if(!(state instanceof ShulkerBox box))
-                            continue;
-
-                        ElevatorType elevatorType = ElevatorHelper.getElevatorType(box);
-                        if(elevatorType == null)
-                            continue;
-
-                        ElevatorHologramService.updateElevatorHologram(new Elevator(box, elevatorType));
-                    }
+            for (World world : Bukkit.getWorlds()) {
+                for (Chunk chunk : world.getLoadedChunks()) {
+                    updateElevatorHologramsInChunk(chunk);
                 }
             }
         });

--- a/src/main/java/com/lkeehl/elevators/services/ElevatorHologramService.java
+++ b/src/main/java/com/lkeehl/elevators/services/ElevatorHologramService.java
@@ -10,6 +10,7 @@ import com.lkeehl.elevators.services.configs.ConfigRoot;
 import com.tcoded.folialib.wrapper.task.WrappedTask;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.Tag;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.ShulkerBox;
 
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Collection;
 
 public class ElevatorHologramService {
 
@@ -70,7 +72,6 @@ public class ElevatorHologramService {
             WrappedHologram hologram = elevatorHolograms.get(location);
             if(!location.getChunk().isLoaded())
                 hologram.delete();
-
         }
     }
 
@@ -115,14 +116,7 @@ public class ElevatorHologramService {
              return;
          }
 
-        for (BlockState state : chunk.getTileEntities()) {
-            if(!(state instanceof ShulkerBox box))
-                continue;
-            ElevatorType elevatorType = ElevatorHelper.getElevatorType(box);
-            if(elevatorType == null)
-                continue;
-            ElevatorHologramService.updateElevatorHologram(new Elevator(box, elevatorType));
-        }
+        updateElevatorHologramsInChunk(chunk);
     }
 
     public static void deleteHologramsInChunk(Chunk chunk) {
@@ -172,6 +166,23 @@ public class ElevatorHologramService {
         hologram.setLines(hologramLines);
         hologram.teleportTo(elevator.getLocation().clone().add(0.5, 1.5 + (hologram.getHeight()) / 2, 0.5));
 
+    }
+
+    public static void updateElevatorHologramsInChunk(Chunk chunk) {
+        Collection<BlockState> tileEntities;
+        if (ElevatorHookService.isServerRunningPaper())
+            tileEntities = chunk.getTileEntities(block -> Tag.SHULKER_BOXES.isTagged(block.getType()), false);
+        else
+            tileEntities = List.of(chunk.getTileEntities());
+
+        for (BlockState state : tileEntities) {
+            if (!(state instanceof ShulkerBox box)) continue;
+
+            ElevatorType elevatorType = ElevatorHelper.getElevatorType(box);
+            if(elevatorType == null) continue;
+
+            ElevatorHologramService.updateElevatorHologram(new Elevator(box, elevatorType));
+        }
     }
 
     public static void updateHologramsOfElevatorType(ElevatorType elevatorType) {

--- a/src/main/java/com/lkeehl/elevators/services/ElevatorHookService.java
+++ b/src/main/java/com/lkeehl/elevators/services/ElevatorHookService.java
@@ -24,8 +24,6 @@ public class ElevatorHookService {
 
     private static final Map<String, ElevatorHook> hookMap = new HashMap<>();
 
-    private static boolean isPaper = false;
-
     public static void init() {
         if(ElevatorHookService.initialized)
             return;
@@ -33,23 +31,6 @@ public class ElevatorHookService {
         ElevatorHookService.buildHooks();
 
         ElevatorHookService.initialized = true;
-    }
-
-    public static void initPaperDetection() {
-        if (hasClass("com.destroystokyo.paper.PaperConfig")
-                || hasClass("io.papermc.paper.configuration.Configuration")) {
-            isPaper = true;
-        }
-    }
-
-    // Taken from PaperLib
-    private static boolean hasClass(String className) {
-        try {
-            Class.forName(className);
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
     }
 
     public static void unInitialize() {
@@ -161,7 +142,7 @@ public class ElevatorHookService {
     }
 
     public static boolean isServerRunningPaper() {
-        return isPaper;
+        return Elevators.getFoliaLib().isPaper();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/com/lkeehl/elevators/services/ElevatorHookService.java
+++ b/src/main/java/com/lkeehl/elevators/services/ElevatorHookService.java
@@ -32,12 +32,14 @@ public class ElevatorHookService {
 
         ElevatorHookService.buildHooks();
 
+        ElevatorHookService.initialized = true;
+    }
+
+    public static void initPaperDetection() {
         if (hasClass("com.destroystokyo.paper.PaperConfig")
                 || hasClass("io.papermc.paper.configuration.Configuration")) {
             isPaper = true;
         }
-
-        ElevatorHookService.initialized = true;
     }
 
     // Taken from PaperLib

--- a/src/main/java/com/lkeehl/elevators/services/ElevatorHookService.java
+++ b/src/main/java/com/lkeehl/elevators/services/ElevatorHookService.java
@@ -32,13 +32,22 @@ public class ElevatorHookService {
 
         ElevatorHookService.buildHooks();
 
-        try {
-            Class.forName("com.destroystokyo.paper.PaperConfig");
+        if (hasClass("com.destroystokyo.paper.PaperConfig")
+                || hasClass("io.papermc.paper.configuration.Configuration")) {
             isPaper = true;
-        } catch (ClassNotFoundException ignored) {
         }
 
         ElevatorHookService.initialized = true;
+    }
+
+    // Taken from PaperLib
+    private static boolean hasClass(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 
     public static void unInitialize() {

--- a/src/main/java/com/lkeehl/elevators/services/ElevatorListenerService.java
+++ b/src/main/java/com/lkeehl/elevators/services/ElevatorListenerService.java
@@ -42,7 +42,6 @@ public class ElevatorListenerService {
         // This might be over-engineered. I may back-track this.
 
         registerEventExecutor(InventoryOpenEvent.class, EventPriority.LOWEST , InventoryEventExecutor::onInventoryOpen);
-        registerEventExecutor(InventoryMoveItemEvent.class, EventPriority.LOWEST , InventoryEventExecutor::onHopperTake);
         registerEventExecutor(InventoryClickEvent.class, EventPriority.HIGHEST, InventoryEventExecutor::onClickStackHandler, true);
         registerEventExecutor(PrepareAnvilEvent.class, EventPriority.LOWEST , InventoryEventExecutor::onAnvilPrepare);
         registerEventExecutor(CraftItemEvent.class, EventPriority.NORMAL , InventoryEventExecutor::onCraft);


### PR DESCRIPTION
- Huge performance improvements achieved by Paper's getTileEntities

- ElevatorListenerService now initialized after ElevatorHookService to fix Paper detection
I just looked at [this](https://github.com/keehl254/Elevators/commit/0dde354f6b3a99d61b0c7402bd8ec3bb77279798) commit and I noticed you moved HookService after ListenerService, is there a reason for that? Since the Paper detection is initialized in the HookService but you call it in ListenerService it will always return false. Yep nvm this breaks the SSB2 hook

- Removed duplicated registration of onHopperTake event

[Spark profile](https://spark.lucko.me/LE37DKSXF8) taken on a Ryzen 7 9700X for 60 seconds with DH and flying with a 8x boost to generate chunks :)