### PR TITLE
Remove holograms from memory and fix explosions

### DIFF
--- a/src/main/java/com/lkeehl/elevators/services/ElevatorHologramService.java
+++ b/src/main/java/com/lkeehl/elevators/services/ElevatorHologramService.java
@@ -106,6 +106,8 @@ public class ElevatorHologramService {
             return;
 
         hologram.delete();
+        elevatorHolograms.remove(elevator.getLocation());
+        holograms.remove(hologram);
     }
 
     public static void loadHologramsInChunk(Chunk chunk) {


### PR DESCRIPTION
I don't know if this was intended behavior, but I don't think it's a good idea not to remove deleted elevators. Fixed the explosions, by default when canExplode is enabled, every single elevator is dropped (correctly).
I tested the plugin after the getState(false) changes and everything seems fine, performance wise the next thing might be canUseHolograms, but caching the value might cause problems when DH is disabled?
Anyway, overall it's a lot less heavy now.

EDIT: Since you don't plan to drop Spigot support we could benefit from using [PaperLib](https://github.com/PaperMC/PaperLib/blob/master/src/main/java/io/papermc/lib/environments/PaperEnvironment.java#L42) to avoid oversights like Inventory#getHolder(boolean) being introduced in 1.16, but like you said we target 1.14 API