### PR TITLE
Fix failure message in Protect hook

### DIFF
--- a/hooks/src/main/java/me/keehl/elevators/services/hooks/ProtectHook.java
+++ b/hooks/src/main/java/me/keehl/elevators/services/hooks/ProtectHook.java
@@ -57,7 +57,7 @@ public class ProtectHook extends ProtectionHook {
     }
 
     public void failed(Player player, String message) {
-        MessageHelper.sendFormattedMessage(player, "<red><dark_gray>[<dark_red><bold>!</bold></dark_red>]</dark_gray> " + message + "</red>");
+        player.sendRichMessage("<red><dark_gray>[<dark_red><bold>!</bold></dark_red>]</dark_gray> " + message + "</red>");
     }
 
     @Override


### PR DESCRIPTION
_`sendRichMessage` is a paper only method, but the Protect plugin can only load on paper servers, so this shouldn't pose any issues_