### PR TITLE
build: add foojay toolchain resolver to settings

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 rootProject.name = "elevators"
 
 include("core", "hooks")


### PR DESCRIPTION
Even with JDK 11 and 21 installed locally, the build currently struggles to map the right versions to the `:core` and `:hooks` modules on different machines.

I've added the Foojay toolchain resolver to `settings.gradle.kts`. This allows Gradle to automatically detect or download the required JDKs for each module, ensuring a smooth "clone and build" experience regardless of the local environment setup.