### PR TITLE
Improve performance

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     compileOnly("com.destroystokyo.paper:paper-api:1.14.4-R0.1-SNAPSHOT") {
         exclude(group = "org.yaml", module = "snakeyaml")
     }
-    implementation("io.papermc:paperlib:1.0.8")
+    implementation("io.github.rvskele:PaperLib:2.0.0")
 
     compileOnly("net.kyori:adventure-text-minimessage:4.14.0")
     compileOnly("net.kyori:adventure-api:4.14.0")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     compileOnly("com.destroystokyo.paper:paper-api:1.14.4-R0.1-SNAPSHOT") {
         exclude(group = "org.yaml", module = "snakeyaml")
     }
-    implementation("io.github.rvskele:PaperLib:2.0.0")
+    implementation("io.github.rvskele:PaperLib:2.1.0")
 
     compileOnly("net.kyori:adventure-text-minimessage:4.14.0")
     compileOnly("net.kyori:adventure-api:4.14.0")

--- a/core/src/main/java/me/keehl/elevators/helpers/ShulkerBoxHelper.java
+++ b/core/src/main/java/me/keehl/elevators/helpers/ShulkerBoxHelper.java
@@ -1,7 +1,6 @@
 package me.keehl.elevators.helpers;
 
-import me.keehl.elevators.Elevators;
-import me.keehl.elevators.services.ElevatorHookService;
+import io.github.rvskele.paperlib.PaperLib;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.*;
@@ -45,10 +44,7 @@ public class ShulkerBoxHelper {
         if (ItemStackHelper.isNotShulkerBox(block.getType()))
             return null;
 
-        if (Elevators.getFoliaLib().isPaper())
-            return (ShulkerBox) block.getState(false);
-
-        return (ShulkerBox) block.getState();
+        return (ShulkerBox) PaperLib.getBlockState(block, false).getState();
     }
 
     public static ShulkerBox clearContents(ShulkerBox box) {
@@ -70,11 +66,7 @@ public class ShulkerBoxHelper {
     public static boolean fakeDispense(Block block, ItemStack item) {
         if (block.getType() != Material.DISPENSER)
             return false;
-        Dispenser dispenser;
-        if (Elevators.getFoliaLib().isPaper())
-            dispenser = (Dispenser) block.getState(false);
-        else
-            dispenser = (Dispenser) block.getState();
+        Dispenser dispenser = (Dispenser) PaperLib.getBlockState(block, false).getState();
 
         Directional directional = (Directional) block.getBlockData();
 

--- a/core/src/main/java/me/keehl/elevators/helpers/VersionHelper.java
+++ b/core/src/main/java/me/keehl/elevators/helpers/VersionHelper.java
@@ -3,7 +3,6 @@ package me.keehl.elevators.helpers;
 import me.keehl.elevators.Elevators;
 import org.bukkit.*;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockState;
 import org.bukkit.block.ShulkerBox;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
@@ -16,7 +15,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 public class VersionHelper {
 
@@ -185,26 +183,6 @@ public class VersionHelper {
         }
         Item item = world.dropItem(location, itemStack);
         alterStackConsumer.accept(item);
-    }
-
-    public static Collection<BlockState> getShulkerBoxesInChunk(Chunk chunk) {
-        java.util.function.Predicate<Block> predicate = block -> TagHelper.SHULKER_BOXES.isTagged(block.getType());
-
-        if(doesVersionSupportPredicateGetChunkEntities()) {
-            try {
-                Method method = chunk.getClass().getMethod("getTileEntities", predicate.getClass(), boolean.class);
-                method.setAccessible(true);
-                return (Collection<BlockState>) method.invoke(chunk, predicate, false);
-            } catch (Exception ignore) {
-            }
-        }
-        BlockState[] states;
-        if(Elevators.getFoliaLib().isPaper())
-            states = chunk.getTileEntities(false);
-        else
-            states = chunk.getTileEntities();
-
-        return Arrays.stream(states).filter(state -> predicate.test(state.getBlock())).collect(Collectors.toList());
     }
 
     public static Collection<BoundingBox> getBoundingBoxes(Block block) {

--- a/core/src/main/java/me/keehl/elevators/listeners/PaperEventExecutor.java
+++ b/core/src/main/java/me/keehl/elevators/listeners/PaperEventExecutor.java
@@ -11,7 +11,7 @@ import me.keehl.elevators.models.ElevatorType;
 import me.keehl.elevators.services.ElevatorConfigService;
 import me.keehl.elevators.services.ElevatorSettingService;
 import me.keehl.elevators.services.ElevatorHookService;
-import io.papermc.lib.PaperLib;
+import io.github.rvskele.paperlib.PaperLib;
 import me.keehl.elevators.util.InternalElevatorSettingType;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/core/src/main/java/me/keehl/elevators/services/ElevatorHologramService.java
+++ b/core/src/main/java/me/keehl/elevators/services/ElevatorHologramService.java
@@ -1,9 +1,9 @@
 package me.keehl.elevators.services;
 
+import io.github.rvskele.paperlib.PaperLib;
 import me.keehl.elevators.Elevators;
 import me.keehl.elevators.helpers.ElevatorHelper;
 import me.keehl.elevators.helpers.MessageHelper;
-import me.keehl.elevators.helpers.VersionHelper;
 import me.keehl.elevators.models.Elevator;
 import me.keehl.elevators.models.ElevatorType;
 import me.keehl.elevators.models.hooks.WrappedHologram;
@@ -127,8 +127,7 @@ public class ElevatorHologramService {
         if (!canUseHolograms())
             return;
 
-        Collection<BlockState> tileEntities = VersionHelper.getShulkerBoxesInChunk(chunk);
-        for (BlockState state : tileEntities) {
+        for (BlockState state : PaperLib.getTileEntities(chunk, false).getTileEntities()) {
             if (!(state instanceof ShulkerBox))
                 continue;
             ShulkerBox box = (ShulkerBox) state;

--- a/hooks/build.gradle.kts
+++ b/hooks/build.gradle.kts
@@ -86,7 +86,7 @@ dependencies {
 
 tasks.shadowJar {
     relocate("com.tcoded.folialib", "me.keehl.elevators.util.folialib")
-    relocate("io.papermc.lib", "me.keehl.elevators.util.paperlib")
+    relocate("io.github.rvskele.paperlib", "me.keehl.elevators.util.paperlib")
     relocate("org.yaml.snakeyaml", "me.keehl.elevators.util.config.snakeyaml")
     relocate("org.bstats", "me.keehl.elevators.util.bstats")
     relocate("dev.faststats", "me.keehl.elevators.util.faststats")


### PR DESCRIPTION
I ended up forking PaperLib and adding the Chunk#getTileEntities method to avoid reflections and other hacky solutions, see: https://github.com/RVSkeLe/PaperLib
- Use PaperLib fork to have a simpler getTileEntities utility
- Small PaperLib refactor