### PR TITLE
Fix Crafter bypass

### DIFF
--- a/hooks/src/main/java/me/keehl/elevators/listeners/AutoCrafterListener.java
+++ b/hooks/src/main/java/me/keehl/elevators/listeners/AutoCrafterListener.java
@@ -18,7 +18,7 @@ public class AutoCrafterListener {
 
     public static void onAutoCraft(CrafterCraftEvent event) {
         ItemStack result = event.getResult();
-        if (result.isEmpty())
+        if (result == null || result.getType() == org.bukkit.Material.AIR)
             return;
         if (ItemStackHelper.isNotShulkerBox(result.getType()))
             return;


### PR DESCRIPTION
Noticed that players could bypass craftPermission by using the Crafter block. Found 
```
[12:02:54 ERROR]: Could not pass event CrafterCraftEvent to Elevators v5.0.0-beta.16 java.lang.NoSuchMethodError: 'boolean org.bukkit.inventory.ItemStack.isEmpty()
```
Can see that the build targets paper version `1.14.4`, which from what I can see don't include the function. This causes the event handler to crash before reaching `setCancelled(true)`, allowing players to bypass. Fixed by removing `isEmpty()` and replacing with `result == null || result.getType() == org.bukkit.Material.AIR`, which should work across all API versions. 

Now this could be an issue with my environment/setup, so if the issue isn't reproduceable please notify me and I'll close the PR. If it actually is a bug I thought I might as well push the fix I did. 