### PR TITLE
[restructure] Fix source builds and migrate FastStats to 0.27.2 (+ jdk17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 [![Documentation](https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/compact/documentation/ghpages_vector.svg)](https://ele.keehl.me)
 
-![Compiled with Java 11](https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3.2.0/assets/compact-minimal/built-with/java11_vector.svg)
+![Compiled with Java 17](https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3.2.0/assets/compact-minimal/built-with/java17_vector.svg)
 ![Supports Paper](https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3.2.0/assets/compact-minimal/supported/paper_vector.svg)
 ![Supports Spigot](https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3.2.0/assets/compact-minimal/supported/spigot_vector.svg)
 [![Supports Folia](assets/Folia.svg)]()
@@ -66,8 +66,8 @@ To build Elevators from source using Gradle:
 
 ## Java Version Notes
 
-The core project and all submodules except Hooks are built using Java 11. The Hooks subproject is written in Java 21.
-A downgrade plugin is used to compile Hooks into a Java 11-compatible format for use in the final build.
+The final plugin targets Java 17. The API subproject targets Java 11, while the Hooks subproject is written in Java 21.
+A downgrade plugin is used to produce the Java 17-compatible plugin JAR.
 Be sure you have both JDK 11 and JDK 21 installed and properly configured if you're developing or building locally.
 
 # License

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import xyz.wagyourtail.jvmdg.gradle.task.ShadeJar
 
 group = "me.keehl"
-version = "5.0.0-beta.24"
+version = "5.0.0-beta.25"
 
 plugins {
     java
@@ -19,6 +19,7 @@ repositories {
     mavenCentral()
     mavenLocal()
 
+    maven("https://repo.faststats.dev/releases")
     maven("https://repo.maven.apache.org/maven2/")
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
     maven("https://oss.sonatype.org/content/repositories/snapshots")
@@ -59,7 +60,7 @@ dependencies {
     implementation(project(":hooks"))
     implementation(project(":api"))
     implementation("org.bstats:bstats-bukkit:3.1.0")
-    implementation("dev.faststats.metrics:bukkit:0.7.5")
+    implementation("dev.faststats.metrics:bukkit:0.27.2")
     implementation("me.keehl:dialog-builder:1.4-SNAPSHOT")
     implementation("com.tcoded:FoliaLib:0.4.3")
     implementation("org.yaml:snakeyaml:2.2")
@@ -91,7 +92,7 @@ bukkit {
     }
 }
 
-jvmdg.downgradeTo = JavaVersion.VERSION_11
+jvmdg.downgradeTo = JavaVersion.VERSION_17
 jvmdg.shadePath = {
     it.substringBefore(".").substringBeforeLast("-").replace(Regex("[.;\\[/]"), "-")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,3 @@
 rootProject.name = "elevators"
 
-include("core", "hooks")
-include("api")
+include("api", "hooks")

--- a/src/main/java/me/keehl/elevators/ElevatorsPlugin.java
+++ b/src/main/java/me/keehl/elevators/ElevatorsPlugin.java
@@ -1,8 +1,8 @@
 package me.keehl.elevators;
 
 import com.tcoded.folialib.FoliaLib;
-import dev.faststats.bukkit.BukkitMetrics;
-import dev.faststats.core.Metrics;
+import dev.faststats.Metrics;
+import dev.faststats.bukkit.BukkitContext;
 import me.keehl.elevators.api.ElevatorsAPI;
 import me.keehl.elevators.api.IElevators;
 import me.keehl.elevators.helpers.ElevatorMenuHelper;
@@ -29,7 +29,7 @@ public class ElevatorsPlugin extends JavaPlugin {
     private static final String BOLD = "\u001B[1m";
 
     private org.bstats.bukkit.Metrics bstatsMetrics;
-    private Metrics fastStatsMetrics;
+    private BukkitContext fastStatsContext;
     private final FoliaLib foliaLib = new FoliaLib(this);
 
     private CustomLogger customLogger;
@@ -68,7 +68,10 @@ public class ElevatorsPlugin extends JavaPlugin {
 
         ElevatorsAPI.pushAndHoldLog();
         try {
-            this.fastStatsMetrics = BukkitMetrics.factory().token("ac50ca9cdff9c38b8a7aeea15b63ded6").create(this);
+            this.fastStatsContext = new BukkitContext.Factory(this, "ac50ca9cdff9c38b8a7aeea15b63ded6")
+                    .metrics(Metrics.Factory::create)
+                    .create();
+            this.fastStatsContext.ready();
         } catch (Exception ex) {
             ElevatorsAPI.log(Level.WARNING, "Failed to load FastStats:\n" + ResourceHelper.cleanTrace(ex));
         }
@@ -98,9 +101,9 @@ public class ElevatorsPlugin extends JavaPlugin {
             this.getLogger().info("Disabling BStats Metrics");
             this.bstatsMetrics.shutdown();
         }
-        if (this.fastStatsMetrics != null) {
+        if (this.fastStatsContext != null) {
             this.getLogger().info("Disabling FastStats Metrics");
-            this.fastStatsMetrics.shutdown();
+            this.fastStatsContext.shutdown();
         }
 
         ElevatorMenuHelper.unregisterDialogManager();


### PR DESCRIPTION
## Summary

- Add the official FastStats Maven repository
- Upgrade FastStats from 0.7.5 to 0.27.2
- Migrate from `BukkitMetrics` to the new `BukkitContext` API
- Update the plugin lifecycle to call `ready()` and `shutdown()`
- Target Java 17 as required by the latest FastStats SDK
- Remove the stale `core` module declaration
- Update the Java requirements in the README

## Verification

[x] `./gradlew clean build`
[x] Confirmed that FastStats is relocated into the final JAR
[x] Confirmed Java 17 compatibility